### PR TITLE
Add reconnection to local server if the connection is lost

### DIFF
--- a/bin/et.js
+++ b/bin/et.js
@@ -54,6 +54,7 @@ const { argv } = yargs
   })
   .option('local_max_reconnect_count', {
     describe: 'Max number of reconnection retries to local server if it goes offline.',
+    default: 90,
   })
   .require('port')
   .boolean('local-https')

--- a/bin/et.js
+++ b/bin/et.js
@@ -52,6 +52,9 @@ const { argv } = yargs
   .option('request-secure-tunnel', {
     describe: 'Requests tunel server to create secure tunnel if it is available.',
   })
+  .option('local_max_reconnect_count', {
+    describe: 'Max number of reconnection retries to local server if it goes offline.',
+  })
   .require('port')
   .boolean('local-https')
   .boolean('allow-invalid-cert')
@@ -77,7 +80,8 @@ if (typeof argv.port !== 'number') {
     local_key: argv.localKey,
     local_ca: argv.localCa,
     allow_invalid_cert: argv.allowInvalidCert,
-    request_secure_tunnel: argv.requestSecureTunnel
+    request_secure_tunnel: argv.requestSecureTunnel,
+    local_max_reconnect_count: argv.local_max_reconnect_count
   }).catch(err => {
     throw err;
   });

--- a/easyTunnel.d.ts
+++ b/easyTunnel.d.ts
@@ -15,6 +15,7 @@ declare interface BootstrapOpts {
     local_ca?: string;
     allow_invalid_cert?: boolean;
     request_secure_tunnel?: boolean;
+    local_max_reconnect_count?: number;
 }
 
 declare const localtunnel: (opts: BootstrapOpts) => Promise<Tunnel>;

--- a/lib/Tunnel.js
+++ b/lib/Tunnel.js
@@ -21,7 +21,7 @@ module.exports = class Tunnel extends EventEmitter {
     /* eslint-disable camelcase */
     const { id, ip, port, url, cached_url, max_conn_count, is_tunnel_secure } = body;
     const { host, port: local_port, local_host } = this.opts;
-    const { local_https, local_cert, local_key, local_ca, allow_invalid_cert } = this.opts;
+    const { local_https, local_cert, local_key, local_ca, allow_invalid_cert, local_max_reconnect_count } = this.opts;
     return {
       name: id,
       url,
@@ -38,6 +38,7 @@ module.exports = class Tunnel extends EventEmitter {
       local_ca,
       allow_invalid_cert,
       is_tunnel_secure,
+      local_max_reconnect_count,
     };
     /* eslint-enable camelcase */
   }

--- a/lib/TunnelCluster.js
+++ b/lib/TunnelCluster.js
@@ -111,8 +111,7 @@ module.exports = class TunnelCluster extends EventEmitter {
         remote.removeListener('close', remoteClose);
         remote.end();
 
-        if(self.localReconnectionRetryCount < localReconnectionMaxRetryCount)
-        {
+        if (self.localReconnectionRetryCount < localReconnectionMaxRetryCount) {
           self.localReconnectionRetryCount++;
           debug(`Local server connection is lost, reconnnecting. Attempt ${self.localReconnectionRetryCount}/${localReconnectionMaxRetryCount}`);
           

--- a/lib/TunnelCluster.js
+++ b/lib/TunnelCluster.js
@@ -11,10 +11,12 @@ module.exports = class TunnelCluster extends EventEmitter {
   constructor(opts = {}) {
     super(opts);
     this.opts = opts;
+    this.localReconnectionRetryCount = 0;  
   }
 
   open() {
     const opt = this.opts;
+    const self = this;
 
     // Prefer IP if returned by the server
     const remoteHostOrIp = opt.remote_ip || opt.remote_host;
@@ -24,6 +26,7 @@ module.exports = class TunnelCluster extends EventEmitter {
     const localProtocol = opt.local_https ? 'https' : 'http';
     const allowInvalidCert = opt.allow_invalid_cert;
     const isTunnelSecure = opt.is_tunnel_secure;
+    const localReconnectionMaxRetryCount = opt.local_max_reconnect_count !== undefined ? opt.local_max_reconnect_count : 90;
 
     debug(
       'establishing tunnel %s://%s:%s <> %s:%s',
@@ -106,18 +109,24 @@ module.exports = class TunnelCluster extends EventEmitter {
         local.end();
 
         remote.removeListener('close', remoteClose);
+        remote.end();
 
-        if (err.code !== 'ECONNREFUSED') {
-          return remote.end();
-        }
-
-        // retrying connection to local server
-        setTimeout(connLocal, 1000);
+        if(self.localReconnectionRetryCount < localReconnectionMaxRetryCount)
+        {
+          self.localReconnectionRetryCount++;
+          debug(`Local server connection is lost, reconnnecting. Attempt ${self.localReconnectionRetryCount}/${localReconnectionMaxRetryCount}`);
+          
+          // retrying connection to local server
+          setTimeout(connLocal, 1000);
+        }        
       });
 
       local.once('connect', () => {
         debug('connected locally');
         remote.resume();
+        
+        debug(`Local reconnection counter is reset at value ${self.localReconnectionRetryCount}`);
+        self.localReconnectionRetryCount = 0;
 
         let stream = remote;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@namecheap/easy-tunnel",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@namecheap/easy-tunnel",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "axios": "0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@namecheap/easy-tunnel",
   "description": "Expose localhost to the world",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
If a local server tends to close connections for some reason (e.g. inactivity timeout), tunneling client shuts down a tunnel event if a local server is operational. 
The fix allows the client to try to reconnect to local server a few times if the connection is lost.